### PR TITLE
Add in DB-Connect (dbx) syntax for inputs.conf

### DIFF
--- a/syntax/splunk.vim
+++ b/syntax/splunk.vim
@@ -172,7 +172,6 @@ syn keyword confInputs suppress_text printSchema remoteAddress process user addr
 syn keyword confInputs protocol readInterval driverBufferSize userBufferSize multikvMaxEventCount multikvMaxTimeMs
 syn keyword confInputs table output.format output.timestamp output.timestamp.column output.timestamp.format
 
-
 " limits.conf
 syn keyword confLimitsStanzas contained default searchresults subsearch anomalousvalue associate autoregress
 syn keyword confLimitsStanzas contained concurrency ctable correlate discretize export extern inputcsv


### PR DESCRIPTION
I added in the syntax specification for the dbx module, which adds additional stanzas to the inputs.conf specification.
