### PR TITLE
macros.conf and eventtypes.conf

### DIFF
--- a/syntax/splunk.vim
+++ b/syntax/splunk.vim
@@ -135,7 +135,7 @@ syn keyword confEventGen spoolDir spoolFile interval count earliest latest break
 syn keyword confEventGen replacement
 
 " eventtypes.conf
-syn match   confEventTypesStanzas contained /\v<(default)>/
+syn match   confEventTypesStanzas contained /\v<(default>|\k+-\%\k+\%)/
 syn keyword confEventTypes disabled search priority description tags
 
 " fields.conf


### PR DESCRIPTION
A couple of things for your consideration. In macros.conf, you have definition lines that contain variables of the format $variable$. In eventtypes.conf, there are some specially-named eventttype stanzas of the form [somelog-%code%] -- when searching you can use eventtype=somelog-404 and splunk would add code=404 to the eventtype's search definition (this is really good for windows logs, i.e. [windows-%event_id%]).

I noticed that I had a few errors with confString and confNumbers. Also, I think its nice to have several of the constant types (numbers, variables) highlighted within strings.
