### PR TITLE
Support highlighting of  `TRANSFORMS-class_with_underscores`

### DIFF
--- a/syntax/spl_props.vim
+++ b/syntax/spl_props.vim
@@ -57,7 +57,7 @@ syn match   confProps /\v<^(maxDist|priority|pulldown_type|rename|sourcetype|una
 " ----------
 syn match   confProps /\v<^(DEPTH_LIMIT)>/
 
-syn match   confComplex /\v<^((EVAL|EXTRACT|FIELDALIAS|LOOKUP|REPORT|SEDCMD|SEGMENTATION|TRANSFORMS)-\w+)>/
+syn match   confComplex /\v<^((EVAL|EXTRACT|FIELDALIAS|LOOKUP|REPORT|SEDCMD|SEGMENTATION|TRANSFORMS)-[0-9A-Za-z_-]+)>/
 syn match   confComplex /\v<^(MORE|LESS)_THAN(\S+_)?\d+>/
 syn keyword confComplex AS OUTPUT OUTPUTNEW
 


### PR DESCRIPTION
Here's a quick local fix that's been laying on my laptop for probably over a year now, figured it was time to share it back :-)

In the past, these `props.conf` entries don't get highlighted:
```
REPORT-my-class-name = my_transforms
TRANSFORMS-myapp-fix_sourcetype = fix_sourcetype
```

This patch fixes that based on my local testing.  Technically this change may be a tad bit overreaching since `EVAL` may or may not support `-` in field names, but I still think this is an improvement without getting too fancy.

On a related note, sometimes a bare `TRANSFORMS = syslog-host` doesn't get highlighted.  But when I double checked in the docs, they don't even mention that this is a possibility.  (Example of this still ships in system/default as of 8.0.2).

Interestingly, the docs go out of there way to point that just about character is valid in a class name for TRANSFORMS, but that's not necessarily tras true for the others...

>   **Note:** `<class>` values do not have to follow field name syntax
>   restrictions. You can use characters other than a-z, A-Z, and 0-9, and
>   spaces are allowed. <class> values are not subject to key cleaning.

But I've never seen spaces in practice, and it seems like that could cause other parsing complications.